### PR TITLE
Mod now no longer resets the builtinTabstrip.SelectedIndex every OnUpdate-Call which prevented other mods to (visually) deselect builtinTabstrip

### DIFF
--- a/ExtendedRoadUpgrade/Mod.cs
+++ b/ExtendedRoadUpgrade/Mod.cs
@@ -356,7 +356,10 @@ namespace ExtendedRoadUpgrade {
                 }
             }
             else {
-                ui.toolMode = ToolMode.None;
+                if (ui.toolMode != ToolMode.None)
+                {
+                    ui.toolMode = ToolMode.None;
+                }
 
                 if (ToolsModifierControl.toolController.CurrentTool == buildTool) {
                     ToolsModifierControl.toolController.CurrentTool = netTool;


### PR DESCRIPTION
Currently if the tool is not enabled (ToolMode=None) in every ThreadingExtension.OnUpdate-Call the ToolMode is set to None, which leads to setting the Selected Index of the builtinTabstrip (the Tab-Buttons with the road tools) to its previous Value (>= 0).
When other mods set the Selected Index to -1, this mod reverts the Selected Index to a value >= 0. That means other mods cannot visually deselect all builtin Tab-Buttons.  

This fix prevents the mod from setting the ToolMode on every OnUpdate-Call -- it now gets only called when the ToolMode is not None.  

Please note: This fix is pretty selfish: I'm working on the [Toggle Traffic Lights Mod](https://steamcommunity.com/sharedfiles/filedetails/?id=411833858). I have there a button placed below the builtin road tools and besides the buttons of this mod. The tool functionality work together -- with the exception that I'm not able to visually deselect the Tab-Buttons because their index gets reset every loop.
